### PR TITLE
Add underline styling to recommended game links

### DIFF
--- a/results/ENFJ.html
+++ b/results/ENFJ.html
@@ -15,10 +15,10 @@
     <section class="results-card">
       <h2>ENFJ는 빠르게 상황을 정리하고 모두를 이끌며 안정감을 줘요.</h2>
       <ol>
-        <li><strong><a href="https://namu.wiki/w/%EC%98%A4%EB%B2%84%EC%9B%8C%EC%B9%98%202">오버워치 2</a></strong> - 역할군을 나눠 협력하며 전장을 지휘하는 5대5 히어로 슈팅.</li>
-        <li><strong><a href="https://namu.wiki/w/It%20Takes%20Two">잇 테이크 투</a></strong> - 두 사람이 힘을 합쳐 퍼즐과 액션을 해결하는 2인 코옵 어드벤처.</li>
-        <li><strong><a href="https://namu.wiki/w/%EB%A1%9C%EC%8A%A4%ED%8A%B8%EC%95%84%ED%81%AC">
-          로스트아크</a></strong> - 공대원과 함께하는 레이드 그리고 감성을 자극하는 퀘스트가 있는 MMORPG</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EC%98%A4%EB%B2%84%EC%9B%8C%EC%B9%98%202">오버워치 2</a> - 역할군을 나눠 협력하며 전장을 지휘하는 5대5 히어로 슈팅.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/It%20Takes%20Two">잇 테이크 투</a> - 두 사람이 힘을 합쳐 퍼즐과 액션을 해결하는 2인 코옵 어드벤처.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EB%A1%9C%EC%8A%A4%ED%8A%B8%EC%95%84%ED%81%AC">
+          로스트아크</a> - 공대원과 함께하는 레이드 그리고 감성을 자극하는 퀘스트가 있는 MMORPG</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/ENFP.html
+++ b/results/ENFP.html
@@ -15,11 +15,11 @@
     <section class="results-card">
       <h2>ENFP는 분위기를 이끄는 추진력을 살려 친구들을 모으고 게임판을 한층 신나게 만들어요.</h2>
       <ol>
-        <li><strong><a href="https://namu.wiki/w/%EC%A0%A4%EB%8B%A4%EC%9D%98%20%EC%A0%84%EC%84%A4%20%ED%8B%B0%EC%96%B4%EC%8A%A4%20%EC%98%A4%EB%B8%8C%20%EB%8D%94%20%ED%82%B9%EB%8D%A4">
-          젤다의 전설: 왕국의 눈물</a></strong> - 광활한 하이랄을 자유롭게 탐험하며 상상력을 마음껏 펼쳐보세요</li>
-        <li><strong><a href="https://namu.wiki/w/%EC%9B%90%EC%8B%A0">
-          원신</a></strong> - 친구(캐릭터)를 모아 세상을 모험하고 유대감을 형성해보세요.</li>
-        <li><strong><a href="https://namu.wiki/w/Life%20is%20Strange">라이프 이즈 스트레인지</a></strong> - 시간여행과 선택을 통해 미스터리를 헤쳐나가는 어드벤처 게임.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EC%A0%A4%EB%8B%A4%EC%9D%98%20%EC%A0%84%EC%84%A4%20%ED%8B%B0%EC%96%B4%EC%8A%A4%20%EC%98%A4%EB%B8%8C%20%EB%8D%94%20%ED%82%B9%EB%8D%A4">
+          젤다의 전설: 왕국의 눈물</a> - 광활한 하이랄을 자유롭게 탐험하며 상상력을 마음껏 펼쳐보세요</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EC%9B%90%EC%8B%A0">
+          원신</a> - 친구(캐릭터)를 모아 세상을 모험하고 유대감을 형성해보세요.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/Life%20is%20Strange">라이프 이즈 스트레인지</a> - 시간여행과 선택을 통해 미스터리를 헤쳐나가는 어드벤처 게임.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/ENTJ.html
+++ b/results/ENTJ.html
@@ -15,9 +15,9 @@
     <section class="results-card">
       <h2>ENTJ는 리더십을 발휘해 팀을 정비하고 승리를 향한 큰 그림을 그려요.</h2>
       <ol>
-        <li><strong><a href="https://namu.wiki/w/%EB%AC%B8%EB%AA%85%206">시드 마이어의 문명 VI</a></strong> - 장기적인 전략으로 문명을 발전시키는 시뮬레이션 게임.</li>
-        <li><strong><a href="https://namu.wiki/w/%ED%86%A0%ED%83%88%20%EC%9B%8C:%20%EC%82%BC%EA%B5%AD">토탈워:삼국</a></strong> - 외교·경제·내정을 통해 국가를 경영하는 토탈워 시리즈의 삼국지 버전.</li>
-        <li><strong><a href="https://namu.wiki/w/%EC%8A%A4%ED%83%80%ED%81%AC%EB%9E%98%ED%94%84%ED%8A%B8%202">스타크래프트 II</a></strong> - 설명이 필요없는 민속놀이 <스타크래프트>의 후속작.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EB%AC%B8%EB%AA%85%206">시드 마이어의 문명 VI</a> - 장기적인 전략으로 문명을 발전시키는 시뮬레이션 게임.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%ED%86%A0%ED%83%88%20%EC%9B%8C:%20%EC%82%BC%EA%B5%AD">토탈워:삼국</a> - 외교·경제·내정을 통해 국가를 경영하는 토탈워 시리즈의 삼국지 버전.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EC%8A%A4%ED%83%80%ED%81%AC%EB%9E%98%ED%94%84%ED%8A%B8%202">스타크래프트 II</a> - 설명이 필요없는 민속놀이 <스타크래프트>의 후속작.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/ENTP.html
+++ b/results/ENTP.html
@@ -15,11 +15,11 @@
     <section class="results-card">
       <h2>ENTP는 새로운 규칙과 전술을 과감하게 시도하며 판을 흔들어요.</h2>
       <ol>
-        <li><strong><a href="https://namu.wiki/w/%EB%AA%AC%EC%8A%A4%ED%84%B0%20%ED%97%8C%ED%84%B0%20%EC%99%80%EC%9D%BC%EC%A6%88">
-          몬스터헌터 와일즈</a></strong> - 파티원과 협동하며 창의적인 방식으로 몬스터를 토벌해보세요.</li>
-        <li><strong><a href="https://namu.wiki/w/%EB%A6%AC%EA%B7%B8%20%EC%98%A4%EB%B8%8C%20%EB%A0%88%EC%A0%84%EB%93%9C">
-          리그 오브 레전드</a></strong> - 같은 챔피언 다른 팀원, 같은 팀원 다른 챔피언. 당신의 전략과 창의성을 펼쳐보세요.</li>
-        <li><strong><a href="https://namu.wiki/w/Portal%202">포탈 2</a></strong> - 포탈건이 2개면 포탈은 4개..? 2인 협동(Co-op) 플레이는 새로운 관점이 필요합니다.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EB%AA%AC%EC%8A%A4%ED%84%B0%20%ED%97%8C%ED%84%B0%20%EC%99%80%EC%9D%BC%EC%A6%88">
+          몬스터헌터 와일즈</a> - 파티원과 협동하며 창의적인 방식으로 몬스터를 토벌해보세요.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EB%A6%AC%EA%B7%B8%20%EC%98%A4%EB%B8%8C%20%EB%A0%88%EC%A0%84%EB%93%9C">
+          리그 오브 레전드</a> - 같은 챔피언 다른 팀원, 같은 팀원 다른 챔피언. 당신의 전략과 창의성을 펼쳐보세요.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/Portal%202">포탈 2</a> - 포탈건이 2개면 포탈은 4개..? 2인 협동(Co-op) 플레이는 새로운 관점이 필요합니다.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/ESFJ.html
+++ b/results/ESFJ.html
@@ -15,12 +15,12 @@
     <section class="results-card">
       <h2>ESFJ는 일정과 역할을 척척 나누며 플레이를 안정적으로 이끌어요.</h2>
       <ol>
-        <li><strong><a href="https://namu.wiki/w/Overcooked!%20%EC%8B%9C%EB%A6%AC%EC%A6%88">
-          오버쿡드! 2</a></strong> - 정신없는 주방 협동 (우정파괴) 게임. 하지만 ESFJ와 함께라면..? </li>
-        <li><strong><a href="https://namu.wiki/w/%EB%AA%A8%EC%97%AC%EB%B4%90%EC%9A%94%20%EB%8F%99%EB%AC%BC%EC%9D%98%20%EC%88%B2">
-          모여봐요 동물의 숲</a></strong> - 마을을 꾸미며 사람들과 교류할 수 있는 힐링 게임. 단, 사람과의 교류는 유료컨텐츠(닌텐도 구독 필요)</li>
-        <li><strong><a href="https://namu.wiki/w/%EA%B7%B8%EB%9D%BC%EC%9A%B4%EB%94%94%EB%93%9C">
-          그라운디드</a></strong> - 고전영화 
+        <li><a class="game-link" href="https://namu.wiki/w/Overcooked!%20%EC%8B%9C%EB%A6%AC%EC%A6%88">
+          오버쿡드! 2</a> - 정신없는 주방 협동 (우정파괴) 게임. 하지만 ESFJ와 함께라면..? </li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EB%AA%A8%EC%97%AC%EB%B4%90%EC%9A%94%20%EB%8F%99%EB%AC%BC%EC%9D%98%20%EC%88%B2">
+          모여봐요 동물의 숲</a> - 마을을 꾸미며 사람들과 교류할 수 있는 힐링 게임. 단, 사람과의 교류는 유료컨텐츠(닌텐도 구독 필요)</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EA%B7%B8%EB%9D%BC%EC%9A%B4%EB%94%94%EB%93%9C">
+          그라운디드</a> - 고전영화 
             <a href="https://namu.wiki/w/%EC%95%A0%EB%93%A4%EC%9D%B4%20%EC%A4%84%EC%97%88%EC%96%B4%EC%9A%94">
               <u><애들이 줄었어요></u></a>의 게임버전. 작아진 내가 정원에 떨어진다면..? 동료들과 협력해서 벌레들로부터 생존하세요</li>
       </ol>

--- a/results/ESFP.html
+++ b/results/ESFP.html
@@ -15,12 +15,12 @@
     <section class="results-card">
       <h2>ESFP는 현장의 분위기를 주도하며 모두를 웃게 만드는 재능이 있어요.</h2>
       <ol>
-        <li><strong><a href="https://namu.wiki/w/%EB%A7%88%EB%A6%AC%EC%98%A4%20%EC%B9%B4%ED%8A%B8%20%EC%9B%94%EB%93%9C">
-          마리오카트 월드</a></strong> - 친구들과 함께 즐길 수 있는 정통 레이싱 파티 게임.</li>
-        <li><strong><a href="https://namu.wiki/w/%ED%8F%AC%ED%8A%B8%EB%82%98%EC%9D%B4%ED%8A%B8">
-          포트나이트</a></strong> - 트렌디한 스킨, 빠른 전투, 건축, 배틀로얄을 즐길 수 있는 역동적인 슈팅 게임.</li>
-        <li><strong><a href="https://namu.wiki/w/%EC%A0%80%EC%8A%A4%ED%8A%B8%20%EB%8C%84%EC%8A%A4%202025%20%EC%97%90%EB%94%94%EC%85%98">
-          저스트 댄스 2025 에디션</a></strong> - 음악에 맞춰 몸을 움직이며 즉흥적으로 에너지를 발산하는 리듬 게임.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EB%A7%88%EB%A6%AC%EC%98%A4%20%EC%B9%B4%ED%8A%B8%20%EC%9B%94%EB%93%9C">
+          마리오카트 월드</a> - 친구들과 함께 즐길 수 있는 정통 레이싱 파티 게임.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%ED%8F%AC%ED%8A%B8%EB%82%98%EC%9D%B4%ED%8A%B8">
+          포트나이트</a> - 트렌디한 스킨, 빠른 전투, 건축, 배틀로얄을 즐길 수 있는 역동적인 슈팅 게임.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EC%A0%80%EC%8A%A4%ED%8A%B8%20%EB%8C%84%EC%8A%A4%202025%20%EC%97%90%EB%94%94%EC%85%98">
+          저스트 댄스 2025 에디션</a> - 음악에 맞춰 몸을 움직이며 즉흥적으로 에너지를 발산하는 리듬 게임.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/ESTJ.html
+++ b/results/ESTJ.html
@@ -15,12 +15,12 @@
     <section class="results-card">
       <h2>ESTJ는 현실적이고 목표지향적이면서 질서를 유지하며 성취를 이루는 유형이에요.</h2>
       <ol>
-        <li><strong><a href="https://namu.wiki/w/%ED%8A%B8%EB%A1%9C%ED%94%BC%EC%BD%94%206">
-          트로피코6</a></strong> - 효율, 조직, 전략.. 그럼 당연히 트로피코. 독재자가 되어 국가를 경영해보세요.</li>
-        <li><strong><a href="https://namu.wiki/w/%EC%8B%9C%ED%8B%B0%EC%A6%88:%20%EC%8A%A4%EC%B9%B4%EC%9D%B4%EB%9D%BC%EC%9D%B8%20II">
-          시티즈: 스카이라인 II</a></strong> - 도로, 토지계획, 지구단위계획을 설계하는 도시 건설 경영 시뮬레이션.</li>
-        <li><strong><a href="https://namu.wiki/w/%EB%A0%88%EC%9D%B8%EB%B3%B4%EC%9A%B0%20%EC%8B%9D%EC%8A%A4%20%EC%8B%9C%EC%A6%88%20X">
-          레인보우 식스 시즈 X</a></strong> - 사격실력(샷빨)보다는 전략과 지휘, 계획적인 진입이 중요한 전술 FPS.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%ED%8A%B8%EB%A1%9C%ED%94%BC%EC%BD%94%206">
+          트로피코6</a> - 효율, 조직, 전략.. 그럼 당연히 트로피코. 독재자가 되어 국가를 경영해보세요.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EC%8B%9C%ED%8B%B0%EC%A6%88:%20%EC%8A%A4%EC%B9%B4%EC%9D%B4%EB%9D%BC%EC%9D%B8%20II">
+          시티즈: 스카이라인 II</a> - 도로, 토지계획, 지구단위계획을 설계하는 도시 건설 경영 시뮬레이션.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%EB%A0%88%EC%9D%B8%EB%B3%B4%EC%9A%B0%20%EC%8B%9D%EC%8A%A4%20%EC%8B%9C%EC%A6%88%20X">
+          레인보우 식스 시즈 X</a> - 사격실력(샷빨)보다는 전략과 지휘, 계획적인 진입이 중요한 전술 FPS.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/ESTP.html
+++ b/results/ESTP.html
@@ -15,12 +15,12 @@
     <section class="results-card">
       <h2>ESTP는 환경을 읽고 순간적인 판단으로 길을 개척해나가요.</h2>
       <ol>
-        <li><strong><a href="https://namu.wiki/w/Project%20Zomboid">
-          프로젝트 좀보이드</a></strong> - 좀비 아포칼립스 세상에서 생존하기 위해선 당신의 판단과 행동력이 필요합니다.</li>
-        <li><strong><a href="https://namu.wiki/w/Grand%20Theft%20Auto%20V">
-          GTA5</a></strong> - 미션은 있지만, 어떻게 할지는 없는 게임. 미션 위치가 멀어서 귀찮으신가요? 헬리콥터나 지나가는 스포츠카를 잠시 빌리시면 됩니다.</li>
-        <li><strong><a href="https://namu.wiki/w/%ED%8F%AC%EB%A5%B4%EC%9E%90%20%ED%98%B8%EB%9D%BC%EC%9D%B4%EC%A6%8C%205">
-          포르자 호라이즌 5</a></strong> - 순간적인 판단하면 레이싱도 빠질수 없지. 레이싱으로 즐기는 오픈월드의 모험.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/Project%20Zomboid">
+          프로젝트 좀보이드</a> - 좀비 아포칼립스 세상에서 생존하기 위해선 당신의 판단과 행동력이 필요합니다.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/Grand%20Theft%20Auto%20V">
+          GTA5</a> - 미션은 있지만, 어떻게 할지는 없는 게임. 미션 위치가 멀어서 귀찮으신가요? 헬리콥터나 지나가는 스포츠카를 잠시 빌리시면 됩니다.</li>
+        <li><a class="game-link" href="https://namu.wiki/w/%ED%8F%AC%EB%A5%B4%EC%9E%90%20%ED%98%B8%EB%9D%BC%EC%9D%B4%EC%A6%8C%205">
+          포르자 호라이즌 5</a> - 순간적인 판단하면 레이싱도 빠질수 없지. 레이싱으로 즐기는 오픈월드의 모험.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/INFJ.html
+++ b/results/INFJ.html
@@ -16,9 +16,9 @@
       <h2>INFJ는 큰 그림을 제시하며 팀이 흔들리지 않도록 든든하게 받쳐줘요. INFJ는 섬세한 감수성으로 팀의 정서를 다독이며 몰입감을 높여줘요.</h2>
       <p>과감한 자신감을 발휘해 주도적으로 플레이를 즐겨보세요! 세심한 시선을 살려 팀원들과 더 깊은 몰입을 경험해보세요!</p>
       <ol>
-        <li><strong><a href="about:blank">저니</a></strong> - 고요한 사막과 유적을 여행하며 깊은 울림을 주는 아트 어드벤처.</li>
-        <li><strong><a href="about:blank">스카이: 빛의 아이들</a></strong> - 협동과 나눔을 통해 하늘 왕국을 밝혀 나가는 소셜 어드벤처.</li>
-        <li><strong><a href="about:blank">그리스</a></strong> - 수채화 같은 비주얼 속에서 감정을 치유하는 정서적 플랫포머.</li>
+        <li><a class="game-link" href="about:blank">저니</a> - 고요한 사막과 유적을 여행하며 깊은 울림을 주는 아트 어드벤처.</li>
+        <li><a class="game-link" href="about:blank">스카이: 빛의 아이들</a> - 협동과 나눔을 통해 하늘 왕국을 밝혀 나가는 소셜 어드벤처.</li>
+        <li><a class="game-link" href="about:blank">그리스</a> - 수채화 같은 비주얼 속에서 감정을 치유하는 정서적 플랫포머.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/INFP.html
+++ b/results/INFP.html
@@ -16,9 +16,9 @@
       <h2>INFP는 자신이 믿는 가치를 바탕으로 팀에 밝은 에너지를 나눠줘요. INFP는 사소한 감정까지 포착하며 팀의 분위기를 부드럽게 만들어요.</h2>
       <p>과감한 자신감을 발휘해 주도적으로 플레이를 즐겨보세요! 세심한 시선을 살려 팀원들과 더 깊은 몰입을 경험해보세요!</p>
       <ol>
-        <li><strong><a href="about:blank">스타듀 밸리</a></strong> - 농장을 가꾸고 마을 사람들과 관계를 쌓는 잔잔한 힐링 시뮬레이션.</li>
-        <li><strong><a href="about:blank">언더테일</a></strong> - 선택과 공감이 전투 결과를 바꾸는 감성 인디 RPG.</li>
-        <li><strong><a href="about:blank">나이트 인 더 우즈</a></strong> - 청춘들의 이야기를 따라가며 감정에 공감하는 어드벤처.</li>
+        <li><a class="game-link" href="about:blank">스타듀 밸리</a> - 농장을 가꾸고 마을 사람들과 관계를 쌓는 잔잔한 힐링 시뮬레이션.</li>
+        <li><a class="game-link" href="about:blank">언더테일</a> - 선택과 공감이 전투 결과를 바꾸는 감성 인디 RPG.</li>
+        <li><a class="game-link" href="about:blank">나이트 인 더 우즈</a> - 청춘들의 이야기를 따라가며 감정에 공감하는 어드벤처.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/INTJ.html
+++ b/results/INTJ.html
@@ -16,9 +16,9 @@
       <h2>INTJ는 목표를 향한 확신으로 팀을 이끌며 명확한 전략을 제시해요. INTJ는 위험 요소를 분석해 안정적인 성과를 내는 데 집중해요.</h2>
       <p>과감한 자신감을 발휘해 주도적으로 플레이를 즐겨보세요! 세심한 시선을 살려 팀원들과 더 깊은 몰입을 경험해보세요!</p>
       <ol>
-        <li><strong><a href="about:blank">크루세이더 킹즈 III</a></strong> - 왕조의 역사를 설계하며 장기 전략을 세우는 대전략 시뮬레이션.</li>
-        <li><strong><a href="about:blank">팩토리오</a></strong> - 복잡한 생산 라인을 설계해 최적화를 추구하는 공장 자동화 시뮬레이션.</li>
-        <li><strong><a href="about:blank">다키스트 던전 II</a></strong> - 위험을 계산하며 파티를 조율해야 하는 고난도 로그라이크 RPG.</li>
+        <li><a class="game-link" href="about:blank">크루세이더 킹즈 III</a> - 왕조의 역사를 설계하며 장기 전략을 세우는 대전략 시뮬레이션.</li>
+        <li><a class="game-link" href="about:blank">팩토리오</a> - 복잡한 생산 라인을 설계해 최적화를 추구하는 공장 자동화 시뮬레이션.</li>
+        <li><a class="game-link" href="about:blank">다키스트 던전 II</a> - 위험을 계산하며 파티를 조율해야 하는 고난도 로그라이크 RPG.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/INTP.html
+++ b/results/INTP.html
@@ -16,9 +16,9 @@
       <h2>INTP는 자신의 가설을 과감하게 검증하며 창의적인 전술을 펼쳐요. INTP는 세부 규칙을 연구하며 정확한 판단으로 팀을 지원해요.</h2>
       <p>과감한 자신감을 발휘해 주도적으로 플레이를 즐겨보세요! 세심한 시선을 살려 팀원들과 더 깊은 몰입을 경험해보세요!</p>
       <ol>
-        <li><strong><a href="about:blank">마인크래프트</a></strong> - 무한한 블록 세계에서 시스템을 설계하고 실험하는 샌드박스.</li>
-        <li><strong><a href="about:blank">옵스 마그눔</a></strong> - 연금 장치를 조립해 효율적인 해법을 찾는 퍼즐 시뮬레이션.</li>
-        <li><strong><a href="about:blank">리턴 오브 더 오브라 딘</a></strong> - 단서와 논리를 엮어 사건을 재구성하는 추리 어드벤처.</li>
+        <li><a class="game-link" href="about:blank">마인크래프트</a> - 무한한 블록 세계에서 시스템을 설계하고 실험하는 샌드박스.</li>
+        <li><a class="game-link" href="about:blank">옵스 마그눔</a> - 연금 장치를 조립해 효율적인 해법을 찾는 퍼즐 시뮬레이션.</li>
+        <li><a class="game-link" href="about:blank">리턴 오브 더 오브라 딘</a> - 단서와 논리를 엮어 사건을 재구성하는 추리 어드벤처.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/ISFJ.html
+++ b/results/ISFJ.html
@@ -16,9 +16,9 @@
       <h2>ISFJ는 든든한 책임감으로 팀의 흐름을 잡아주며 믿음을 주어요. ISFJ는 작은 실수도 보듬어 주며 편안한 플레이를 돕고 싶어 해요.</h2>
       <p>과감한 자신감을 발휘해 주도적으로 플레이를 즐겨보세요! 세심한 시선을 살려 팀원들과 더 깊은 몰입을 경험해보세요!</p>
       <ol>
-        <li><strong><a href="about:blank">포켓몬 스칼렛·바이올렛</a></strong> - 친숙한 동료와 모험을 이어가며 이야기를 완성하는 RPG.</li>
-        <li><strong><a href="about:blank">드래곤 퀘스트 빌더즈 2</a></strong> - 섬을 복구하고 사람들을 돕는 따뜻한 건설 RPG.</li>
-        <li><strong><a href="about:blank">코지 그로브</a></strong> - 영혼 친구들을 돌보며 하루를 차분하게 채우는 힐링 시뮬레이션.</li>
+        <li><a class="game-link" href="about:blank">포켓몬 스칼렛·바이올렛</a> - 친숙한 동료와 모험을 이어가며 이야기를 완성하는 RPG.</li>
+        <li><a class="game-link" href="about:blank">드래곤 퀘스트 빌더즈 2</a> - 섬을 복구하고 사람들을 돕는 따뜻한 건설 RPG.</li>
+        <li><a class="game-link" href="about:blank">코지 그로브</a> - 영혼 친구들을 돌보며 하루를 차분하게 채우는 힐링 시뮬레이션.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/ISFP.html
+++ b/results/ISFP.html
@@ -16,9 +16,9 @@
       <h2>ISFP는 자신이 좋아하는 감성을 거리낌 없이 표현하며 분위기를 물들여요. ISFP는 조용히 디테일을 채우며 팀에 안정감을 전달해요.</h2>
       <p>과감한 자신감을 발휘해 주도적으로 플레이를 즐겨보세요! 세심한 시선을 살려 팀원들과 더 깊은 몰입을 경험해보세요!</p>
       <ol>
-        <li><strong><a href="about:blank">케나: 브릿지 오브 스피리츠</a></strong> - 자연과 조화를 이루며 영혼을 치유하는 감성 액션 어드벤처.</li>
-        <li><strong><a href="about:blank">하이파이 러시</a></strong> - 음악 비트에 맞춰 전투를 펼치는 스타일리시 액션.</li>
-        <li><strong><a href="about:blank">세이블</a></strong> - 미지의 사막을 탐험하며 자신만의 길을 찾는 예술적 어드벤처.</li>
+        <li><a class="game-link" href="about:blank">케나: 브릿지 오브 스피리츠</a> - 자연과 조화를 이루며 영혼을 치유하는 감성 액션 어드벤처.</li>
+        <li><a class="game-link" href="about:blank">하이파이 러시</a> - 음악 비트에 맞춰 전투를 펼치는 스타일리시 액션.</li>
+        <li><a class="game-link" href="about:blank">세이블</a> - 미지의 사막을 탐험하며 자신만의 길을 찾는 예술적 어드벤처.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/ISTJ.html
+++ b/results/ISTJ.html
@@ -16,9 +16,9 @@
       <h2>ISTJ는 침착한 리더십으로 팀에 안정감을 주며 규칙을 정리해요. ISTJ는 체크리스트처럼 꼼꼼히 과정을 점검하며 완성도를 높여요.</h2>
       <p>과감한 자신감을 발휘해 주도적으로 플레이를 즐겨보세요! 세심한 시선을 살려 팀원들과 더 깊은 몰입을 경험해보세요!</p>
       <ol>
-        <li><strong><a href="about:blank">몬스터 헌터 라이즈</a></strong> - 세밀한 준비와 패턴 분석으로 거대한 몬스터를 사냥하는 액션 RPG.</li>
-        <li><strong><a href="about:blank">트라이앵글 스트래티지</a></strong> - 전략적인 시나리오 선택과 진형 운용이 중요한 SRPG.</li>
-        <li><strong><a href="about:blank">스노우러너</a></strong> - 난관이 가득한 지형을 계획적으로 돌파하는 오프로드 시뮬레이션.</li>
+        <li><a class="game-link" href="about:blank">몬스터 헌터 라이즈</a> - 세밀한 준비와 패턴 분석으로 거대한 몬스터를 사냥하는 액션 RPG.</li>
+        <li><a class="game-link" href="about:blank">트라이앵글 스트래티지</a> - 전략적인 시나리오 선택과 진형 운용이 중요한 SRPG.</li>
+        <li><a class="game-link" href="about:blank">스노우러너</a> - 난관이 가득한 지형을 계획적으로 돌파하는 오프로드 시뮬레이션.</li>
       </ol>
     </section>
     <div class="actions">

--- a/results/ISTP.html
+++ b/results/ISTP.html
@@ -16,9 +16,9 @@
       <h2>ISTP는 냉철한 판단으로 팀에 필요한 돌파구를 제시해요. ISTP는 위험을 계산하며 안정적인 해결책을 찾아내요.</h2>
       <p>과감한 자신감을 발휘해 주도적으로 플레이를 즐겨보세요! 세심한 시선을 살려 팀원들과 더 깊은 몰입을 경험해보세요!</p>
       <ol>
-        <li><strong><a href="about:blank">엘든 링</a></strong> - 치밀한 전투 감각과 탐험이 요구되는 오픈월드 액션 RPG.</li>
-        <li><strong><a href="about:blank">섀도 오브 더 툼 레이더</a></strong> - 기민한 액션과 퍼즐을 넘나드는 탐험형 어드벤처.</li>
-        <li><strong><a href="about:blank">포르자 호라이즌 5</a></strong> - 광활한 멕시코를 질주하며 차량을 자유롭게 조율하는 레이싱.</li>
+        <li><a class="game-link" href="about:blank">엘든 링</a> - 치밀한 전투 감각과 탐험이 요구되는 오픈월드 액션 RPG.</li>
+        <li><a class="game-link" href="about:blank">섀도 오브 더 툼 레이더</a> - 기민한 액션과 퍼즐을 넘나드는 탐험형 어드벤처.</li>
+        <li><a class="game-link" href="about:blank">포르자 호라이즌 5</a> - 광활한 멕시코를 질주하며 차량을 자유롭게 조율하는 레이싱.</li>
       </ol>
     </section>
     <div class="actions">

--- a/styles.css
+++ b/styles.css
@@ -226,8 +226,12 @@ header p {
   font-size: 17px;
 }
 
-.results-card li strong {
+.results-card li .game-link {
   color: #5560ff;
+  font-weight: 700;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
 }
 
 .actions {


### PR DESCRIPTION
## Summary
- replace the `<strong>` wrappers around recommended game names with anchors that use a shared `game-link` class across the MBTI result pages
- style the new `game-link` class to underline and embolden recommended game links for clearer affordance

## Testing
- not run (static assets only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690ff89de120832085892e110c070bf1)