### PR TITLE
Add recommended games index page and update MBTI result navigation

### DIFF
--- a/recommended-games.html
+++ b/recommended-games.html
@@ -1,0 +1,439 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MBTI별 추천 게임 전체 목록</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="results-page">
+  <main>
+    <header>
+      <h1>MBTI별 추천 게임 전체 목록</h1>
+      <p>각 MBTI 유형에 맞춰 추천된 게임을 한눈에 살펴보고, 새로운 게임을 발견해보세요.</p>
+    </header>
+    <section class="games-list">
+      <article class="mbti-card" id="enfj">
+        <h2>ENFJ</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%98%A4%EB%B2%84%EC%9B%8C%EC%B9%98%202">오버워치 2</a>
+              <span class="mbti-badge">ENFJ</span>
+            </div>
+            <p>역할군을 나눠 협력하며 전장을 지휘하는 5대5 히어로 슈팅.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/It%20Takes%20Two">잇 테이크 투</a>
+              <span class="mbti-badge">ENFJ</span>
+            </div>
+            <p>두 사람이 힘을 합쳐 퍼즐과 액션을 해결하는 2인 코옵 어드벤처.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EB%A1%9C%EC%8A%A4%ED%8A%B8%EC%95%84%ED%81%AC">로스트아크</a>
+              <span class="mbti-badge">ENFJ</span>
+            </div>
+            <p>공대원과 함께하는 레이드 그리고 감성을 자극하는 퀘스트가 있는 MMORPG</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="enfp">
+        <h2>ENFP</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%A0%A4%EB%8B%A4%EC%9D%98%20%EC%A0%84%EC%84%A4%20%ED%8B%B0%EC%96%B4%EC%8A%A4%20%EC%98%A4%EB%B8%8C%20%EB%8D%94%20%ED%82%B9%EB%8D%A4">젤다의 전설: 왕국의 눈물</a>
+              <span class="mbti-badge">ENFP</span>
+            </div>
+            <p>광활한 하이랄을 자유롭게 탐험하며 상상력을 마음껏 펼쳐보세요</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%9B%90%EC%8B%A0">원신</a>
+              <span class="mbti-badge">ENFP</span>
+            </div>
+            <p>친구(캐릭터)를 모아 세상을 모험하고 유대감을 형성해보세요.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/Life%20is%20Strange">라이프 이즈 스트레인지</a>
+              <span class="mbti-badge">ENFP</span>
+            </div>
+            <p>시간여행과 선택을 통해 미스터리를 헤쳐나가는 어드벤처 게임.</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="entj">
+        <h2>ENTJ</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EB%AC%B8%EB%AA%85%206">시드 마이어의 문명 VI</a>
+              <span class="mbti-badge">ENTJ</span>
+            </div>
+            <p>장기적인 전략으로 문명을 발전시키는 시뮬레이션 게임.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%ED%86%A0%ED%83%88%20%EC%9B%8C:%20%EC%82%BC%EA%B5%AD">토탈워:삼국</a>
+              <span class="mbti-badge">ENTJ</span>
+            </div>
+            <p>외교·경제·내정을 통해 국가를 경영하는 토탈워 시리즈의 삼국지 버전.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%8A%A4%ED%83%80%ED%81%AC%EB%9E%98%ED%94%84%ED%8A%B8%202">스타크래프트 II</a>
+              <span class="mbti-badge">ENTJ</span>
+            </div>
+            <p>설명이 필요없는 민속놀이 &lt;스타크래프트&gt;의 후속작.</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="entp">
+        <h2>ENTP</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EB%AA%AC%EC%8A%A4%ED%84%B0%20%ED%97%8C%ED%84%B0%20%EC%99%80%EC%9D%BC%EC%A6%88">몬스터헌터 와일즈</a>
+              <span class="mbti-badge">ENTP</span>
+            </div>
+            <p>파티원과 협동하며 창의적인 방식으로 몬스터를 토벌해보세요.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EB%A6%AC%EA%B7%B8%20%EC%98%A4%EB%B8%8C%20%EB%A0%88%EC%A0%84%EB%93%9C">리그 오브 레전드</a>
+              <span class="mbti-badge">ENTP</span>
+            </div>
+            <p>같은 챔피언 다른 팀원, 같은 팀원 다른 챔피언. 당신의 전략과 창의성을 펼쳐보세요.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/Portal%202">포탈 2</a>
+              <span class="mbti-badge">ENTP</span>
+            </div>
+            <p>포탈건이 2개면 포탈은 4개..? 2인 협동(Co-op) 플레이는 새로운 관점이 필요합니다.</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="esfj">
+        <h2>ESFJ</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/Overcooked!%20%EC%8B%9C%EB%A6%AC%EC%A6%88">오버쿡드! 2</a>
+              <span class="mbti-badge">ESFJ</span>
+            </div>
+            <p>정신없는 주방 협동 (우정파괴) 게임. 하지만 ESFJ와 함께라면..?</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EB%AA%A8%EC%97%AC%EB%B4%90%EC%9A%94%20%EB%8F%99%EB%AC%BC%EC%9D%98%20%EC%88%B2">모여봐요 동물의 숲</a>
+              <span class="mbti-badge">ESFJ</span>
+            </div>
+            <p>마을을 꾸미며 사람들과 교류할 수 있는 힐링 게임. 단, 사람과의 교류는 유료컨텐츠(닌텐도 구독 필요)</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EA%B7%B8%EB%9D%BC%EC%9A%B4%EB%94%94%EB%93%9C">그라운디드</a>
+              <span class="mbti-badge">ESFJ</span>
+            </div>
+            <p>고전영화 &lt;애들이 줄었어요&gt;의 게임버전. 작아진 내가 정원에 떨어진다면..? 동료들과 협력해서 벌레들로부터 생존하세요</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="esfp">
+        <h2>ESFP</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EB%A7%88%EB%A6%AC%EC%98%A4%20%EC%B9%B4%ED%8A%B8%20%EC%9B%94%EB%93%9C">마리오카트 월드</a>
+              <span class="mbti-badge">ESFP</span>
+            </div>
+            <p>친구들과 함께 즐길 수 있는 정통 레이싱 파티 게임.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%ED%8F%AC%ED%8A%B8%EB%82%98%EC%9D%B4%ED%8A%B8">포트나이트</a>
+              <span class="mbti-badge">ESFP</span>
+            </div>
+            <p>트렌디한 스킨, 빠른 전투, 건축, 배틀로얄을 즐길 수 있는 역동적인 슈팅 게임.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%A0%80%EC%8A%A4%ED%8A%B8%20%EB%8C%84%EC%8A%A4%202025%20%EC%97%90%EB%94%94%EC%85%98">저스트 댄스 2025 에디션</a>
+              <span class="mbti-badge">ESFP</span>
+            </div>
+            <p>음악에 맞춰 몸을 움직이며 즉흥적으로 에너지를 발산하는 리듬 게임.</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="estj">
+        <h2>ESTJ</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%ED%8A%B8%EB%A1%9C%ED%94%BC%EC%BD%94%206">트로피코6</a>
+              <span class="mbti-badge">ESTJ</span>
+            </div>
+            <p>효율, 조직, 전략.. 그럼 당연히 트로피코. 독재자가 되어 국가를 경영해보세요.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%8B%9C%ED%8B%B0%EC%A6%88:%20%EC%8A%A4%EC%B9%B4%EC%9D%B4%EB%9D%BC%EC%9D%B8%20II">시티즈: 스카이라인 II</a>
+              <span class="mbti-badge">ESTJ</span>
+            </div>
+            <p>도로, 토지계획, 지구단위계획을 설계하는 도시 건설 경영 시뮬레이션.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EB%A0%88%EC%9D%B8%EB%B3%B4%EC%9A%B0%20%EC%8B%9D%EC%8A%A4%20%EC%8B%9C%EC%A6%88%20X">레인보우 식스 시즈 X</a>
+              <span class="mbti-badge">ESTJ</span>
+            </div>
+            <p>사격실력(샷빨)보다는 전략과 지휘, 계획적인 진입이 중요한 전술 FPS.</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="estp">
+        <h2>ESTP</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/Project%20Zomboid">프로젝트 좀보이드</a>
+              <span class="mbti-badge">ESTP</span>
+            </div>
+            <p>좀비 아포칼립스 세상에서 생존하기 위해선 당신의 판단과 행동력이 필요합니다.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/Grand%20Theft%20Auto%20V">GTA5</a>
+              <span class="mbti-badge">ESTP</span>
+            </div>
+            <p>미션은 있지만, 어떻게 할지는 없는 게임. 미션 위치가 멀어서 귀찮으신가요? 헬리콥터나 지나가는 스포츠카를 잠시 빌리시면 됩니다.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%ED%8F%AC%EB%A5%B4%EC%9E%90%20%ED%98%B8%EB%9D%BC%EC%9D%B4%EC%A6%8C%205">포르자 호라이즌 5</a>
+              <span class="mbti-badge">ESTP</span>
+            </div>
+            <p>순간적인 판단하면 레이싱도 빠질수 없지. 레이싱으로 즐기는 오픈월드의 모험.</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="infj">
+        <h2>INFJ</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EB%94%94%ED%8A%B8%EB%A1%9C%EC%9D%B4%ED%8A%B8:%20%EB%B9%84%EC%BB%B4%20%ED%9C%B4%EB%A8%BC">디트로이트: 비컴 휴먼</a>
+              <span class="mbti-badge">INFJ</span>
+            </div>
+            <p>사람과 구분할 수 없는 안드로이드가 상용화된 미래, &#x27;인간이란 무엇인가?&#x27;를 성찰하는 게임.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/Journey(%EA%B2%8C%EC%9E%84)">저니</a>
+              <span class="mbti-badge">INFJ</span>
+            </div>
+            <p>텍스트 없이 비주얼과 음악으로 진행되는 인디게임. 감성과 분위기를 중시하는 INFJ에게 추천.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%8A%A4%ED%85%94%EB%9D%BC%20%EB%B8%94%EB%A0%88%EC%9D%B4%EB%93%9C">스텔라블레이드</a>
+              <span class="mbti-badge">INFJ</span>
+            </div>
+            <p>화려한 액션 뒷면의 생존투쟁과 신앙, 그리고 거대한 계획. &#x27;마더 스피어시여 우리를 구원하소서..&#x27;</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="infp">
+        <h2>INFP</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/To%20the%20Moon">투더문</a>
+              <span class="mbti-badge">INFP</span>
+            </div>
+            <p>한 노인의 마지막 소원을 이루어주기 위한 여정에서 사랑과 후회, 인생의 의미를 돌이켜보는 게임.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%96%B8%EB%8D%94%ED%85%8C%EC%9D%BC">언더테일</a>
+              <span class="mbti-badge">INFP</span>
+            </div>
+            <p>선택과 공감이 전투 결과를 바꾸는 감성 인디 RPG.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%98%A5%ED%86%A0%ED%8C%A8%EC%8A%A4%20%ED%8A%B8%EB%9E%98%EB%B8%94%EB%9F%AC%20II">옥토패스 트래블러</a>
+              <span class="mbti-badge">INFP</span>
+            </div>
+            <p>각 캐릭터의 이야기를 따라가며 감정에 공감하고 성장해가는 어드벤처.</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="intj">
+        <h2>INTJ</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%ED%81%AC%EB%A3%A8%EC%84%B8%EC%9D%B4%EB%8D%94%20%ED%82%B9%EC%A6%88%203">크루세이더 킹즈 III</a>
+              <span class="mbti-badge">INTJ</span>
+            </div>
+            <p>왕조의 역사를 설계하며 장기 전략을 세우는 대전략 시뮬레이션.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%ED%8C%A9%ED%86%A0%EB%A6%AC%EC%98%A4">팩토리오</a>
+              <span class="mbti-badge">INTJ</span>
+            </div>
+            <p>복잡한 생산 라인을 설계해 최적화를 추구하는 공장 자동화 시뮬레이션.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EB%8B%A4%ED%82%A4%EC%8A%A4%ED%8A%B8%20%EB%8D%98%EC%A0%84%202">다키스트 던전 II</a>
+              <span class="mbti-badge">INTJ</span>
+            </div>
+            <p>위험을 계산하며 파티를 조율해야 하는 로그라이크 RPG.</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="intp">
+        <h2>INTP</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%97%AD%EC%A0%84%EC%9E%AC%ED%8C%90%20%EC%8B%9C%EB%A6%AC%EC%A6%88">역전재판 시리즈</a>
+              <span class="mbti-badge">INTP</span>
+            </div>
+            <p>모순된 증거와 증언의 허점을 파고드는 추리게임. 이 추천에 반대한다면 이의있음!</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%8A%A4%ED%85%8C%ED%8D%BC%20%EC%BC%80%EC%9D%B4%EC%8A%A4:%20%EC%B4%88%EB%8A%A5%EB%A0%A5%20%EC%B6%94%EB%A6%AC%20%EC%96%B4%EB%93%9C%EB%B2%A4%EC%B2%98">스태퍼 케이스</a>
+              <span class="mbti-badge">INTP</span>
+            </div>
+            <p>초능력에 의해 일어난 사건사고들, 하지만 사건해결에는 초능력보다느 논리가 중요.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/The%20Witness">더 위트니스</a>
+              <span class="mbti-badge">INTP</span>
+            </div>
+            <p>눈을 떠보니 모르는 섬이다. 단서를 발견하고 당신의 논리력을 이용해 섬을 탈출하세요.</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="isfj">
+        <h2>ISFJ</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/Stardew%20Valley">스타듀 밸리</a>
+              <span class="mbti-badge">ISFJ</span>
+            </div>
+            <p>농장을 가꾸고 마을 사람들과 교류할 수 있는 힐링 게임. 작물의 효율은 잠시 내려놓으셔도 됩니다.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EB%8D%B0%EC%9D%B4%EB%B8%8C%20%EB%8D%94%20%EB%8B%A4%EC%9D%B4%EB%B2%84">데이브 더 다이버</a>
+              <span class="mbti-badge">ISFJ</span>
+            </div>
+            <p>낮에는 해양 생태계를 조사하고, 밤에는 초밥집을 운영하는 탐험 경영시뮬레이션 게임.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/Spiritfarer">스피릿 페어러</a>
+              <span class="mbti-badge">ISFJ</span>
+            </div>
+            <p>영혼 친구들을 돌보며 하루를 차분하게 채우고 배를 확장하는 힐링 건설 시뮬레이션.</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="isfp">
+        <h2>ISFP</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%BC%80%EB%82%98:%20%EB%B8%8C%EB%A6%BF%EC%A7%80%20%EC%98%A4%EB%B8%8C%20%EC%8A%A4%ED%94%BC%EB%A6%BF">케나: 브릿지 오브 스피리츠</a>
+              <span class="mbti-badge">ISFP</span>
+            </div>
+            <p>자연과 조화를 이루며 영혼을 치유하는 감성 액션 어드벤처.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/Hi-Fi%20Rush">하이파이 러시</a>
+              <span class="mbti-badge">ISFP</span>
+            </div>
+            <p>음악 비트에 맞춰 전투를 펼치는 스타일리시 액션.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%ED%99%9C%ED%98%91%EC%A0%84">활협전</a>
+              <span class="mbti-badge">ISFP</span>
+            </div>
+            <p>쓰러져가는 당문의 마지막 외성제자 조활이 되어 문파와 당신의 미래를 바꿔보세요.</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="istj">
+        <h2>ISTJ</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://store.steampowered.com/app/1435790/_/?l=koreana">익스케이프 시뮬레이터</a>
+              <span class="mbti-badge">ISTJ</span>
+            </div>
+            <p>방탈출 시뮬레이션 게임. 주변 환경을 분석하고 추리하여 퍼즐을 맞춰보세요.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/Uncover%20the%20Smoking%20Gun">언커버 더 스모킹건</a>
+              <span class="mbti-badge">ISTJ</span>
+            </div>
+            <p>안드로이드에 의한 사건을 해결하세요. 선택지 없이 취조하고 싶은대로 용의로봇을 추궁해도 됩니다.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%97%91%EC%8A%A4%EC%BB%B4%202">XCOM 2</a>
+              <span class="mbti-badge">ISTJ</span>
+            </div>
+            <p>외계 침공에 맞서는 엑스컴이 되어 위치, 확률, 위험을 계산하는 전략 게임. &#x27;감나빗&#x27;의 그 게임</p>
+          </li>
+        </ol>
+      </article>
+      <article class="mbti-card" id="istp">
+        <h2>ISTP</h2>
+        <ol>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%97%98%EB%93%A0%20%EB%A7%81">엘든 링</a>
+              <span class="mbti-badge">ISTP</span>
+            </div>
+            <p>치밀한 전투와 탐험을 할 수 있는 오픈월드 액션 RPG.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/%EC%84%80%EB%8F%84%20%EC%98%A4%EB%B8%8C%20%EB%8D%94%20%ED%88%BC%20%EB%A0%88%EC%9D%B4%EB%8D%94">섀도 오브 더 툼 레이더</a>
+              <span class="mbti-badge">ISTP</span>
+            </div>
+            <p>실시간 액션과 퍼즐을 넘나드는 탐험 어드벤처 시리즈.</p>
+          </li>
+          <li>
+            <div class="game-heading">
+              <a class="game-link" href="https://namu.wiki/w/Vampire%20Survivors">뱀파이어 서바이버즈</a>
+              <span class="mbti-badge">ISTP</span>
+            </div>
+            <p>&#x27;Easy to play, Hard to master.&#x27; 다양한 무기와 패시브를 조합하며 살아남는 인디 로그라이크 게임</p>
+          </li>
+        </ol>
+      </article>
+    </section>
+    <div class="actions">
+      <a class="primary" href="index.html">처음으로 돌아가기</a>
+      <a class="secondary" href="all-results.html">전체 MBTI결과 보기</a>
+    </div>
+  </main>
+</body>
+</html>

--- a/results/ENFJ.html
+++ b/results/ENFJ.html
@@ -23,7 +23,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/ENFP.html
+++ b/results/ENFP.html
@@ -24,7 +24,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/ENTJ.html
+++ b/results/ENTJ.html
@@ -22,7 +22,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/ENTP.html
+++ b/results/ENTP.html
@@ -24,7 +24,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/ESFJ.html
+++ b/results/ESFJ.html
@@ -27,7 +27,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/ESFP.html
+++ b/results/ESFP.html
@@ -25,7 +25,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/ESTJ.html
+++ b/results/ESTJ.html
@@ -25,7 +25,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/ESTP.html
+++ b/results/ESTP.html
@@ -25,7 +25,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/INFJ.html
+++ b/results/INFJ.html
@@ -24,7 +24,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/INFP.html
+++ b/results/INFP.html
@@ -25,7 +25,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/INTJ.html
+++ b/results/INTJ.html
@@ -25,7 +25,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/INTP.html
+++ b/results/INTP.html
@@ -25,7 +25,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/ISFJ.html
+++ b/results/ISFJ.html
@@ -25,7 +25,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/ISFP.html
+++ b/results/ISFP.html
@@ -25,7 +25,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/ISTJ.html
+++ b/results/ISTJ.html
@@ -25,7 +25,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/results/ISTP.html
+++ b/results/ISTP.html
@@ -25,7 +25,8 @@
     </section>
     <div class="actions">
       <a class="primary" href="../index.html">처음으로 돌아가기</a>
-      <a class="secondary" href="../all-results.html">전체 결과 보기</a>
+      <a class="secondary" href="../recommended-games.html">추천게임 전체목록 보기</a>
+      <a class="secondary" href="../all-results.html">전체 MBTI결과 보기</a>
     </div>
   </main>
 </body>

--- a/styles.css
+++ b/styles.css
@@ -234,6 +234,69 @@ header p {
   text-underline-offset: 3px;
 }
 
+.games-list {
+  margin-top: 40px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.mbti-card {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 24px;
+  padding: 24px 24px 28px;
+  box-shadow: 0 16px 36px rgba(40, 56, 120, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.mbti-card h2 {
+  margin: 0;
+  font-size: clamp(22px, 3vw, 28px);
+}
+
+.mbti-card ol {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.mbti-card li {
+  margin-bottom: 16px;
+  font-size: 16px;
+}
+
+.mbti-card li:last-child {
+  margin-bottom: 0;
+}
+
+.game-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mbti-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: #5560ff;
+  color: #fff;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.mbti-card li p {
+  margin: 8px 0 0;
+  color: #3c3d52;
+  line-height: 1.6;
+}
+
 .actions {
   margin-top: 40px;
   display: flex;
@@ -306,6 +369,10 @@ header p {
 
 @media (max-width: 600px) {
   .all-results-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .games-list {
     grid-template-columns: 1fr;
   }
 


### PR DESCRIPTION
## Summary
- add a new recommended-games.html page that consolidates the recommended titles for every MBTI type
- add a "추천게임 전체목록 보기" button to each MBTI result page and update the wording on the existing all-results link
- extend the shared stylesheet with styles for the aggregated list layout and badges

## Testing
- No automated tests were run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691071783d0c8320800880a4e26fa4b9)